### PR TITLE
Allow users to --exclude files and dirs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -46,6 +46,11 @@ You can also use regexps in your whitelist by delimiting them with //'s.
 
 * sudo gem install debride
 
+== CONTRIBUTING:
+
+* sudo gem install minitest
+* ruby -Ilib:test test/test_debride.rb
+
 == LICENSE:
 
 (The MIT License)

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -59,7 +59,11 @@ class Debride < MethodBasedSexpProcessor
     opt = parse_options args
 
     debride = Debride.new opt
-    debride.run expand_dirs_to_files(args)
+
+    files = expand_dirs_to_files(args)
+    files -= expand_dirs_to_files(debride.option[:exclude]) if debride.option[:exclude]
+
+    debride.run(files)
     debride
   end
 
@@ -109,6 +113,10 @@ class Debride < MethodBasedSexpProcessor
       opts.on("-h", "--help", "Display this help.") do
         puts opts
         exit
+      end
+
+      opts.on("-e", "--exclude FILE1,FILE2,ETC", Array, "Exclude files or directories in comma-separated list.") do |list|
+        options[:exclude] = list
       end
 
       opts.on("-w", "--whitelist FILE", String, "Whitelist these messages.") do |s|

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -31,9 +31,24 @@ class TestDebride < Minitest::Test
     assert_option %w[-v woot.rb], %w[woot.rb], :verbose => true
   end
 
+  def test_parse_options_exclude
+    assert_option %w[--exclude moot.rb],   %w[],    :exclude => %w[moot.rb]
+    assert_option %w[-e moot lib],         %w[lib], :exclude => %w[moot]
+    assert_option %w[-e moot,moot.rb lib], %w[lib], :exclude => %w[moot moot.rb]
+  end
+
   def test_parse_options_whitelist
     exp = File.readlines("Manifest.txt").map(&:chomp) # omg dumb
     assert_option %w[--whitelist Manifest.txt], %w[], :whitelist => exp
+  end
+
+  def test_exclude_files
+    debride = Debride.run %w[--exclude test .]
+
+    exp = [["Debride",
+            [:process_call, :process_defn, :process_defs, :process_rb, :report]]]
+
+    assert_equal exp, debride.missing
   end
 
   def test_whitelist


### PR DESCRIPTION
# Examples

Scan the current directory but exclude the `test` directory:
```
debride --exclude test .
```

Scan the current directory but exclude the `test` and `vendor` directories:
```
debride --exclude test,vendor .
```