### PR TITLE
Add failing test case with alias_method_chain.

### DIFF
--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -54,4 +54,26 @@ class TestDebride < Minitest::Test
 
     assert_equal exp, debride.missing
   end
+
+  def test_alias_method_chain
+    file = Tempfile.new ["debride_test", ".rb"]
+
+    file.write <<-RUBY.strip
+      class QuarterPounder
+        def royale_with_cheese
+          1+1
+        end
+
+        alias_method_chain :royale, :cheese
+      end
+    RUBY
+
+    file.flush
+
+    debride = Debride.run [file.path, "--rails"]
+
+    exp = [["QuarterPounder", [:royale_with_cheese]]]
+
+    assert_equal exp, debride.missing
+  end
 end


### PR DESCRIPTION
Like I mentioned the other day, debride fails when the file to parse has `alias_method_chain` in it:

```
pete@balloon:~/projects/debride$ cat qp.rb 
class QuarterPounder
  def royale_with_cheese
    1+1
  end

  alias_method_chain :royale, :cheese
end
pete@balloon:~/projects/debride$ ruby -Ilib -S bin/debride qp.rb --rails
These methods MIGHT not be called:
/home/pete/projects/debride/lib/debride.rb:219:in `=~': no implicit conversion of Sexp into String (TypeError)
	from /home/pete/projects/debride/lib/debride.rb:219:in `block in missing'
	from /home/pete/projects/debride/lib/debride.rb:219:in `reject!'
	from /home/pete/projects/debride/lib/debride.rb:219:in `missing'
	from /home/pete/projects/debride/lib/debride.rb:242:in `report'
	from bin/debride:5:in `<main>'
```

I added a failing test demonstrating the issue, but I wasn't sure what the desired behavior was.