### PR TITLE
Handling of attr_* methods

### DIFF
--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -322,6 +322,7 @@ class Debride < MethodBasedSexpProcessor
     method_name = sexp[2]
     method_name = method_name.last if Sexp === method_name
     called << method_name
+    process_until_empty sexp
     sexp
   end
 

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -259,6 +259,25 @@ class Debride < MethodBasedSexpProcessor
       new_name = sexp[3]
       new_name = new_name.last if Sexp === new_name # when is this NOT the case?
       known[new_name] << klass_name if option[:rails]
+    when :attr_accessor then
+      sexp[3..-1].each do |name|
+        new_name = name # Antics to avoid warnings regarding shadow variable
+        new_name = new_name.last if Sexp === new_name # because alias_method_chain does it
+        known[new_name] << klass_name
+        known["#{new_name}=".to_sym] << klass_name
+      end
+    when :attr_writer then
+      sexp[3..-1].each do |name|
+        new_name = name # Antics to avoid warnings regarding shadow variable
+        new_name = new_name.last if Sexp === new_name # because alias_method_chain does it
+        known["#{new_name}=".to_sym] << klass_name
+      end
+    when :attr_reader then
+      sexp[3..-1].each do |name|
+        new_name = name # Antics to avoid warnings regarding shadow variable
+        new_name = new_name.last if Sexp === new_name # because alias_method_chain does it
+        known[new_name] << klass_name
+      end
     when :send, :public_send, :__send__ then
       sent_method = sexp[3]
       if Sexp === sent_method && [:lit, :str].include?(sent_method.first)
@@ -296,6 +315,13 @@ class Debride < MethodBasedSexpProcessor
 
     process_until_empty sexp
 
+    sexp
+  end
+
+  def process_attrasgn(sexp)
+    method_name = sexp[2]
+    method_name = method_name.last if Sexp === method_name
+    called << method_name
     sexp
   end
 

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -251,4 +251,23 @@ class TestDebride < Minitest::Test
 
     assert_process [["AttributeAccessor", [:a1=, :a2, :a3, :r2, :w2=]]], ruby
   end
+
+  def test_attr_accessor_with_hash_default_value
+    ruby = <<-RUBY.strip
+      class AttributeAccessor
+        attr_accessor :a1
+        def initialize(options = {})
+          self.a1 = options.fetch(:a1) { default_a1 }
+        end
+
+        def default_a1
+          'the default_a1'
+        end
+      end
+
+      object = AttributeAccessor.new
+    RUBY
+
+    assert_process [["AttributeAccessor", [:a1]]], ruby
+  end
 end

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -230,4 +230,25 @@ class TestDebride < Minitest::Test
 
     assert_process [["Constants", [:UNUSED]]], ruby
   end
+
+  def test_attr_accessor
+    ruby = <<-RUBY.strip
+      class AttributeAccessor
+        attr_accessor :a1, :a2, :a3
+        attr_writer :w1, :w2
+        attr_reader :r1, :r2
+        def initialize
+          self.a2 = 'Bar'
+          self.w1 = 'W'
+        end
+      end
+
+      object = AttributeAccessor.new
+      object.a1
+      object.r1
+      object.a3 = 'Baz'
+    RUBY
+
+    assert_process [["AttributeAccessor", [:a1=, :a2, :a3, :r2, :w2=]]], ruby
+  end
 end


### PR DESCRIPTION
Treat calls to attr_* methods as method definitions. Also treat
attribute assignment as a method call.