### PR TITLE
Fix crash when --verbose is provided

### DIFF
--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -100,7 +100,7 @@ class Debride < MethodBasedSexpProcessor
 
   def process_rb path_or_io
     begin
-      warn "processing: #{path}" if option[:verbose]
+      warn "processing: #{path_or_io}" if option[:verbose]
 
       case path_or_io
       when String then


### PR DESCRIPTION
I was seeing the following when running `debride --verbose .`:

```
/home/devstep/ruby/lib/ruby/gems/2.2.0/gems/debride-1.4.0/lib/debride.rb:103:in `process_rb':
undefined local variable or method `path' for #<Debride:0x007fcabda83240> (NameError)
```