### PR TITLE
Add debride-slim reference

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -49,6 +49,7 @@ You can also use regexps in your whitelist by delimiting them with //'s.
 debride-erb  :: Extends debride to analyze erb files (via erubis ala rails).
 debride-haml :: Plugin to allow debride to parse Haml files.
 debride-curly :: A plugin for the Curly templating language
+debride-slim :: Extends debride to analyze Slim files
 
 == REQUIREMENTS:
 


### PR DESCRIPTION
So, there's `debride-{erb,haml,curly}`. Slim is another very popular template language. Taking inspiration on `debride-haml`, here's [debride-slim](https://rubygems.org/gems/debride-slim).

This updates the README with the added reference.