### PR TITLE
Update rails support

### DIFF
--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -421,12 +421,16 @@ class Debride < MethodBasedSexpProcessor
     end
   end
 
+  ##
+  # Rails' macro-style methods that setup method calls to happen during a rails
+  # app's execution.
+
   RAILS_DSL_METHODS = [
     :after_action,
     :around_action,
     :before_action,
 
-    # http://api.rubyonrails.org/v4.2.1/classes/ActiveRecord/Callbacks.html
+    # http://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html
     :after_commit,
     :after_create,
     :after_destroy,
@@ -451,8 +455,12 @@ class Debride < MethodBasedSexpProcessor
     :validate,
   ]
 
-  # http://api.rubyonrails.org/v4.2.1/classes/ActiveModel/Validations/HelperMethods.html
+  ##
+  # Rails' macro-style methods that count as method calls if their options
+  # include +:if+ or +:unless+.
+
   RAILS_VALIDATION_METHODS = [
+    # http://api.rubyonrails.org/classes/ActiveModel/Validations/HelperMethods.html
     :validates,
     :validates_absence_of,
     :validates_acceptance_of,
@@ -465,6 +473,9 @@ class Debride < MethodBasedSexpProcessor
     :validates_presence_of,
     :validates_size_of,
   ]
+
+  ##
+  # Rails' macro-style methods that define methods dynamically.
 
   RAILS_MACRO_METHODS = [
     :belongs_to,

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -285,6 +285,11 @@ class Debride < MethodBasedSexpProcessor
           end
         end
       end
+    when *RAILS_MACRO_METHODS
+      # s(:call, nil, :has_one, s(:lit, :has_one_relation), ...)
+      _, _, _, (_, name), * = sexp
+      file, line = sexp.file, sexp.line
+      record_method name, file, line
     when /_path$/ then
       method_name = method_name.to_s[0..-6].to_sym if option[:rails]
     end
@@ -459,5 +464,13 @@ class Debride < MethodBasedSexpProcessor
     :validates_numericality_of,
     :validates_presence_of,
     :validates_size_of,
+  ]
+
+  RAILS_MACRO_METHODS = [
+    :belongs_to,
+    :has_and_belongs_to_many,
+    :has_many,
+    :has_one,
+    :scope,
   ]
 end

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -267,7 +267,7 @@ class Debride < MethodBasedSexpProcessor
         # s(:call, nil, :before_save, s(:lit, :save_callback), s(:hash, ...))
         if RAILS_DSL_METHODS.include?(method_name)
           _, _, _, (_, new_name), * = sexp
-          called << new_name
+          called << new_name if new_name
         end
         possible_hash = sexp.last
         if Sexp === possible_hash && possible_hash.sexp_type == :hash

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -262,29 +262,29 @@ class Debride < MethodBasedSexpProcessor
       if Sexp === msg_arg && [:lit, :str].include?(msg_arg.sexp_type) then
         called << msg_arg.last.to_sym
       end
-     when *RAILS_VALIDATION_METHODS then
-       if option[:rails]
-         possible_hash = sexp.last
-         if Sexp === possible_hash && possible_hash.sexp_type == :hash
-           possible_hash.sexp_body.each_slice(2) do |key, val|
-             called << val.last        if val.first == :lit
-             called << val.last.to_sym if val.first == :str
-           end
-         end
-       end
-     when *RAILS_DSL_METHODS then
-       if option[:rails]
-         # s(:call, nil, :before_save, s(:lit, :save_callback), s(:hash, ...))
-         _, _, _, (_, new_name), possible_hash = sexp
-         called << new_name
-         if Sexp === possible_hash && possible_hash.sexp_type == :hash
-           possible_hash.sexp_body.each_slice(2) do |key, val|
-             next unless Sexp === val
-             called << val.last        if val.first == :lit
-             called << val.last.to_sym if val.first == :str
-           end
-         end
-       end
+    when *RAILS_VALIDATION_METHODS then
+      if option[:rails]
+        possible_hash = sexp.last
+        if Sexp === possible_hash && possible_hash.sexp_type == :hash
+          possible_hash.sexp_body.each_slice(2) do |key, val|
+            called << val.last        if val.first == :lit
+            called << val.last.to_sym if val.first == :str
+          end
+        end
+      end
+    when *RAILS_DSL_METHODS then
+      if option[:rails]
+        # s(:call, nil, :before_save, s(:lit, :save_callback), s(:hash, ...))
+        _, _, _, (_, new_name), possible_hash = sexp
+        called << new_name
+        if Sexp === possible_hash && possible_hash.sexp_type == :hash
+          possible_hash.sexp_body.each_slice(2) do |key, val|
+            next unless Sexp === val
+            called << val.last        if val.first == :lit
+            called << val.last.to_sym if val.first == :str
+          end
+        end
+      end
     when /_path$/ then
       method_name = method_name.to_s[0..-6].to_sym if option[:rails]
     end

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -223,6 +223,10 @@ class TestDebride < Minitest::Test
         after_save :save_callback, if: lambda {|r| true }
         validates :database_column, if: :validation_condition
         validate :some_validation_method
+
+        before_save do
+          foo.bar
+        end
       end
     RUBY
 

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -229,6 +229,47 @@ class TestDebride < Minitest::Test
     assert_process [], ruby, :rails => true
   end
 
+  def test_rails_dsl_macro_definitions
+    ruby = <<-RUBY.strip
+      class RailsModel
+        has_one :has_one_relation
+        has_one :uncalled_has_one_relation
+        belongs_to :belongs_to_relation
+        belongs_to :uncalled_belongs_to_relation
+        has_many :has_many_relation
+        has_many :uncalled_has_many_relation
+        has_and_belongs_to_many :has_and_belongs_to_many_relation
+        has_and_belongs_to_many :uncalled_has_and_belongs_to_many_relation
+        scope :scope_method
+        scope :uncalled_scope_method
+
+        def instance_method_caller
+          has_one_relation
+          belongs_to_relation
+          has_many_relation
+          has_and_belongs_to_many_relation
+        end
+
+        def self.class_method_caller
+          scope_method
+        end
+
+        class_method_caller
+        new.instance_method_caller
+      end
+    RUBY
+
+    unused_methods = [
+      :uncalled_belongs_to_relation,
+      :uncalled_has_and_belongs_to_many_relation,
+      :uncalled_has_many_relation,
+      :uncalled_has_one_relation,
+      :uncalled_scope_method,
+    ]
+
+    assert_process [["RailsModel", unused_methods]], ruby, :rails => true
+  end
+
   def test_constants
     ruby = <<-RUBY.strip
       class Constants


### PR DESCRIPTION
I noticed the other day that debride did not count scopes and relations as method definitions in rails models. This PR aims to fix that.

While I was in here I did a few more odds and ends:

* Fixed some indentation.
* Added documentation for the different sets of rails macros.
* Combined two blocks of code that were almost the same.
* Made sure debride did not blow up with the inline block form of rails macros (eg, `before_save { do_stuff }`).