### PR TITLE
skip parsing file when file contains non escaped no ASCII charactor.

### DIFF
--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -87,7 +87,7 @@ class Debride < MethodBasedSexpProcessor
 
       begin
         process send(msg, file)
-      rescue RuntimeError, SyntaxError => e
+      rescue RuntimeError, SyntaxError, RegexpError => e
         warn "  skipping #{file}: #{e.message}"
       end
     end


### PR DESCRIPTION
connected to: #34 Should rescue RegexpError while parsing file.

I resolve it.

updated log is below.

```
$ rake run D="./throw_regexperror_sample.rb"
WARNING: invalid multibyte character: /\【/ for "\\【" ""
WARNING: trying to recover with ENC_UTF8
WARNING: trying to recover with ENC_NONE
  skipping ./throw_regexperror_sample.rb: /.../n has a non escaped non ASCII character in non ASCII-8BIT script: /\【/
These methods MIGHT not be called:
```