### PR TITLE
create YamlFormatter.

### DIFF
--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -120,7 +120,7 @@ class Debride < MethodBasedSexpProcessor
   # Parse command line options and return a hash of parsed option values.
 
   def self.parse_options args
-    options = {:whitelist => []}
+    options = {:whitelist => [], :formatter => 'Formatter::BaseFormatter'}
 
     op = OptionParser.new do |opts|
       opts.banner  = "debride [options] files_or_dirs"
@@ -159,6 +159,10 @@ class Debride < MethodBasedSexpProcessor
 
       opts.on("-v", "--verbose", "Verbose. Show progress processing files.") do
         options[:verbose] = true
+      end
+
+      opts.on("-f", "--format type", String, "Set formatter formatting log.") do |formatter|
+        options[:formatter] = 'Formatter::YamlFormatter' if ['yml', 'yaml'].include? formatter
       end
     end
 
@@ -393,25 +397,7 @@ class Debride < MethodBasedSexpProcessor
     end
 
     puts "These methods MIGHT not be called:"
-
-    missing.each do |klass, meths|
-      bad = meths.map { |meth|
-        location =
-          method_locations["#{klass}##{meth}"] ||
-          method_locations["#{klass}::#{meth}"]
-        path = location[/(.+):\d+$/, 1]
-
-        next if focus and not File.fnmatch(focus, path)
-
-        "  %-35s %s" % [meth, location]
-      }
-      bad.compact!
-      next if bad.empty?
-
-      puts
-      puts klass
-      puts bad.join "\n"
-    end
+    Object.const_get(option[:formatter]).do(missing, method_locations, focus)
   end
 
   ##

--- a/lib/formatter/base_formatter.rb
+++ b/lib/formatter/base_formatter.rb
@@ -1,0 +1,34 @@
+module Formatter
+  class BaseFormatter
+    FORMAT = "  %-35s %s".freeze
+
+    def self.do(missing, method_locations, focus)
+      missing.each do |klass, meths|
+        bad = meths.map do |meth|
+          location =
+            method_locations["#{klass}##{meth}"] ||
+            method_locations["#{klass}::#{meth}"]
+          path = location[/(.+):\d+$/, 1]
+
+          next if focus && !File.fnmatch(focus, path)
+
+          self.format(meth, location)
+        end
+        bad.compact!
+        next if bad.empty?
+
+        self.put_log(klass, bad)
+      end
+    end
+
+    def self.format(meth, location)
+      FORMAT % [meth, location]
+    end
+
+    def self.put_log(klass, bad)
+      puts
+      puts klass
+      puts bad.join "\n"
+    end
+  end
+end

--- a/lib/formatter/yaml_formatter.rb
+++ b/lib/formatter/yaml_formatter.rb
@@ -1,0 +1,15 @@
+module Formatter
+  class YamlFormatter < BaseFormatter
+    FORMAT = "  - %-35s # %s".freeze
+
+    def self.format(meth, location)
+      FORMAT % [meth, location]
+    end
+
+    def self.put_log(klass, bad)
+      puts
+      puts "#{klass}:"
+      puts bad.join "\n"
+    end
+  end
+end


### PR DESCRIPTION
I added an option `--format` and `YamlFormatter`.
It is a key factor using linter like `debride` that reusing linter log to import another libraries.
For make more useful `debride` I added `YamlFormatter`.

If you like it, merge this PR :)

usage of `--format` is looks like below.

```
debride [options] files_or_dirs

Specific options:

    -h, --help                       Display this help.
    -e, --exclude FILE1,FILE2,ETC    Exclude files or directories in comma-separated list.
    -w, --whitelist FILE             Whitelist these messages.
        --focus PATH                 Only report against this path
    -r, --rails                      Add some rails call conversions.
    -v, --verbose                    Verbose. Show progress processing files.
    -f, --format                     Set formatter formatting log.
```

```
$ debride ./app/models -f yml
These methods MIGHT not be called:
Address:
  - address_detail                      # ./app/models/address.rb:315-321
```

