### PR TITLE
JBuilder support

### DIFF
--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -50,7 +50,7 @@ class Debride < MethodBasedSexpProcessor
   end
 
   def self.file_extensions
-    %w[rb rake] + load_plugins
+    %w[rb rake jbuilder] + load_plugins
   end
 
   ##


### PR DESCRIPTION
I'm using gem for rails application, then I notice that .jbuilder file is not supported.
Jbuilder is pure ruby code, so I added ``jbuilder`` to ``self.file_extensions`` simply.