### PR TITLE
fix for focus mode throwing nil error

### DIFF
--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -415,7 +415,7 @@ class Debride < MethodBasedSexpProcessor
         location =
           method_locations["#{klass}##{meth}"] ||
           method_locations["#{klass}::#{meth}"]
-        path = location[/(.+):\d+$/, 1]
+        path = location[/^(.+):/, 1]
 
         next if focus and not File.fnmatch(focus, path)
 


### PR DESCRIPTION
If focus mode is specified, this regex parsing returns a nil since the format is a numeric range, we only need the path for comparison before : so simplifying it this way fixes the issue

e.g
if I specify -f app/models/account.rb

and a candidate unused model method is
app/models/account.rb:121-122

path will be nil using the old regexp
and we will get a nil error on File.fnmatch(focus, path) 
