### PR TITLE
Several improvements incl GraphQL option & addtl called detection

### DIFF
--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -150,6 +150,10 @@ class Debride < MethodBasedSexpProcessor
         options[:rails] = true
       end
 
+      opts.on("-r", "--graphql", "Add some graphql-ruby call conversions.") do
+        options[:graphql] = true
+      end
+
       opts.on("-m", "--minimum N", Integer, "Don't show hits less than N locs.") do |n|
         options[:minimum] = n
       end
@@ -315,6 +319,15 @@ class Debride < MethodBasedSexpProcessor
       if context.include? :module or context.include? :class then
         file, line = sexp.file, sexp.line
         record_method name, file, line
+      end
+    when *GRAPHQL_OBJECT_METHODS then
+      if option[:graphql]
+        # s(:call, nil, :field, s(:lit, :field_name), ...)
+        _, _, _, (_, name), * = sexp
+
+        if context.include? :module or context.include? :class then
+          method_name = name
+        end
       end
     when /_path$/ then
       method_name = method_name.to_s.delete_suffix("_path").to_sym if option[:rails]
@@ -594,5 +607,12 @@ class Debride < MethodBasedSexpProcessor
     :has_many,
     :has_one,
     :scope,
+  ]
+
+  ##
+  # GraphQL defining a field means that a method is used to resolve a field in the schema.
+
+  GRAPHQL_OBJECT_METHODS = [
+    :field,
   ]
 end

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -277,7 +277,7 @@ class Debride < MethodBasedSexpProcessor
         end
         record_method name, file, line
       end
-    when :send, :public_send, :__send__ then
+    when :send, :public_send, :__send__, :try then
       # s(:call, s(:const, :Seattle), :send, s(:lit, :raining?))
       _, _, _, msg_arg, * = sexp
       if Sexp === msg_arg && [:lit, :str].include?(msg_arg.sexp_type) then

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -224,6 +224,14 @@ class Debride < MethodBasedSexpProcessor
     sexp
   end
 
+  # handle &&=, ||=, etc
+  def process_op_asgn2(sexp)
+    _, _, method_name, * = sexp
+    called << method_name
+    process_until_empty sexp
+    sexp
+  end
+
   def record_method name, file, line
     signature = "#{klass_name}##{name}"
     method_locations[signature] = "#{file}:#{line}"

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -335,6 +335,16 @@ class Debride < MethodBasedSexpProcessor
       method_name = method_name.to_s.delete_prefix("deliver_").to_sym if option[:rails]
     end
 
+    # check if the call has a block shorthand argument, etc. E.g. for `.each(&:empty?)`, `empty?` is called
+    sexp.each do |arg|
+      next unless Sexp === arg
+      next unless arg.sexp_type == :block_pass
+      _, block = arg
+      next unless Sexp === block
+      next unless block.sexp_type == :lit
+      called << block.last
+    end
+
     called << method_name
 
     process_until_empty sexp

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -415,6 +415,8 @@ class Debride < MethodBasedSexpProcessor
     end
   end
 
+  alias process_safe_call process_call
+
   ##
   # Calculate the difference between known methods and called methods.
 

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -285,7 +285,7 @@ class Debride < MethodBasedSexpProcessor
         end
         record_method name, file, line
       end
-    when :send, :public_send, :__send__, :try then
+    when :send, :public_send, :__send__, :try, :const_get then
       # s(:call, s(:const, :Seattle), :send, s(:lit, :raining?))
       _, _, _, msg_arg, * = sexp
       if Sexp === msg_arg && [:lit, :str].include?(msg_arg.sexp_type) then

--- a/lib/debride.rb
+++ b/lib/debride.rb
@@ -295,6 +295,12 @@ class Debride < MethodBasedSexpProcessor
           called << val.last.to_sym if val.sexp_type == :str
         end
       end
+    when :method then
+      # s(:call, nil, :method, s(:lit, :foo))
+      _, _, _, msg_arg, * = sexp
+      if Sexp === msg_arg && [:lit, :str].include?(msg_arg.sexp_type) then
+        called << msg_arg.last.to_sym
+      end
     when *RAILS_DSL_METHODS, *RAILS_VALIDATION_METHODS then
       if option[:rails]
         # s(:call, nil, :before_save, s(:lit, :save_callback), s(:hash, ...))

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -314,6 +314,24 @@ class TestDebride < Minitest::Test
     assert_process [], ruby, :rails => true
   end
 
+  def test_graphql_dsl_methods
+    ruby = <<-RUBY.strip
+      class Thing
+        def id = 1
+        def name = 1
+      end
+
+      module GraphQL
+        class ThingObject < GraphQL::Schema::Object
+          field :id, ID, null: false
+          field :name, String, null: true
+        end
+      end
+    RUBY
+
+    assert_process [], ruby, :graphql => true
+  end
+
   def test_rails_dsl_macro_definitions
     ruby = <<-RUBY.strip
       class RailsModel

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -301,6 +301,20 @@ class TestDebride < Minitest::Test
     assert_process [], ruby
   end
 
+  def test_method_block_shorthand
+    ruby = <<-RUBY.strip
+      class Seattle
+        def self.raining?
+          true
+        end
+      end
+
+      [Seattle].each(&:raining?)
+    RUBY
+
+    assert_process [], ruby
+  end
+
   def test_safe_navigation_operator
     ruby = <<-RUBY.strip
       class Seattle

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -287,6 +287,20 @@ class TestDebride < Minitest::Test
     assert_process [], ruby
   end
 
+  def test_method_try
+    ruby = <<-RUBY.strip
+      class Seattle
+        def self.raining?
+          true
+        end
+      end
+
+      Seattle.try :raining?
+    RUBY
+
+    assert_process [], ruby
+  end
+
   def test_safe_navigation_operator
     ruby = <<-RUBY.strip
       class Seattle

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -329,6 +329,24 @@ class TestDebride < Minitest::Test
     assert_process [], ruby
   end
 
+  def test_method_with_symbol_to_proc
+    ruby = <<-RUBY.strip
+      class Seattle
+        def self.raining?
+          true
+        end
+
+        def self.raining_still?
+          method(:raining?).to_proc.call
+        end
+      end
+
+      Seattle.raining_still?
+    RUBY
+
+    assert_process [], ruby
+  end
+
   def test_rails_dsl_methods
     ruby = <<-RUBY.strip
       class RailsThing

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -287,6 +287,20 @@ class TestDebride < Minitest::Test
     assert_process [], ruby
   end
 
+  def test_safe_navigation_operator
+    ruby = <<-RUBY.strip
+      class Seattle
+        def self.raining?
+          true
+        end
+      end
+
+      Seattle&.raining?
+    RUBY
+
+    assert_process [], ruby
+  end
+
   def test_rails_dsl_methods
     ruby = <<-RUBY.strip
       class RailsThing

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -439,6 +439,8 @@ class TestDebride < Minitest::Test
       class Constants
         USED = 42
         ALSO = 314
+        AGAIN = 27
+        MORE = 72
         UNUSED = 24
 
         def something
@@ -449,6 +451,8 @@ class TestDebride < Minitest::Test
       something
       Constants::ALSO
       ::Constants::ALSO
+      Constants.const_get(:AGAIN)
+      ::Constants.const_get("MORE")
     RUBY
 
     assert_process [["Constants", [:UNUSED]]], ruby

--- a/test/test_debride.rb
+++ b/test/test_debride.rb
@@ -17,6 +17,7 @@ class TestDebride < Minitest::Test
                 :process_const,
                 :process_defn,
                 :process_defs,
+                :process_op_asgn2,
                 :process_rb,
                 :report,
                 :report_json,
@@ -457,11 +458,13 @@ class TestDebride < Minitest::Test
     ruby = <<-RUBY.strip
       class AttributeAccessor
         attr_accessor :a1, :a2, :a3
-        attr_writer :w1, :w2
+        attr_writer :w1, :w2, :w3, :w4
         attr_reader :r1, :r2
         def initialize
           self.a2 = 'Bar'
           self.w1 = 'W'
+          self.w3 ||= 'W3'
+          self.w4 &&= 'W4'
         end
 
         def self.class_method
@@ -486,10 +489,12 @@ class TestDebride < Minitest::Test
            "AttributeAccessor#a3="        => "(io):2",
            "AttributeAccessor#w1="        => "(io):3",
            "AttributeAccessor#w2="        => "(io):3",
+           "AttributeAccessor#w3="        => "(io):3",
+           "AttributeAccessor#w4="        => "(io):3",
            "AttributeAccessor#r1"         => "(io):4",
            "AttributeAccessor#r2"         => "(io):4",
-           "AttributeAccessor#initialize" => "(io):5-7",
-           "AttributeAccessor::class_method" => "(io):10-11"
+           "AttributeAccessor#initialize" => "(io):5-9",
+           "AttributeAccessor::class_method" => "(io):12-13"
           }
 
     assert_equal exp, d.method_locations


### PR DESCRIPTION
Adds a bunch of extra `called` detection which should benefit all users of this gem.

---

Also adds an option `--graphql` to handle the graphql-ruby behavior:

```ruby
field :name, String, null: true
```

the default resolution behavior for a field called `name` is to invoke the `name` method on the object.
